### PR TITLE
Set EXPATH in init function

### DIFF
--- a/src/init.rs
+++ b/src/init.rs
@@ -1,7 +1,9 @@
 use std::path::PathBuf;
 use std::env;
+use crate::EXPATH;
 
 pub(crate) fn init() {
+    EXPATH.set(get_expath()).unwrap();
 }
 
 fn get_expath() -> PathBuf {


### PR DESCRIPTION
Close #15 .
# Contents
Set EXPATH in init function
# Reason
I want to set EXPATH.
# Impact
EXPATH is set when running init.