### PR TITLE
Delete EXPATH variable

### DIFF
--- a/src/init.rs
+++ b/src/init.rs
@@ -1,6 +1,5 @@
 use std::path::PathBuf;
 use std::env;
-use crate::EXPATH;
 
 pub(crate) fn init() {
 }

--- a/src/init.rs
+++ b/src/init.rs
@@ -6,7 +6,7 @@ pub(crate) fn init() {
     EXPATH.set(get_expath()).unwrap();
 }
 
-fn get_expath() -> PathBuf {
+pub(crate) fn get_expath() -> PathBuf {
     let expath = match env::var("EXPATH") {
         Ok(path) => PathBuf::from(path),
         Err(_) => {

--- a/src/init.rs
+++ b/src/init.rs
@@ -3,7 +3,6 @@ use std::env;
 use crate::EXPATH;
 
 pub(crate) fn init() {
-    EXPATH.set(get_expath()).unwrap();
 }
 
 pub(crate) fn get_expath() -> PathBuf {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,8 +2,6 @@ use once_cell::sync::OnceCell;
 use std::path::PathBuf;
 mod init;
 
-pub(crate) static EXPATH: OnceCell<PathBuf> = OnceCell::new();
-
 fn main() {
     init::init();
     println!("Hello, world!");


### PR DESCRIPTION
Close #19 .
# Contents
Delete EXPATH variable.
# Reason
If you use get_expath, you don't need it anymore.
# Impact
Expose get_expath function to the entire crate.
Remove all init processing.
Uninstall EXPATH from init.rs.
Delete EXPATH variable from main.rs.