### PR TITLE
Change std::env::home_dir to dirs::home_dir

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,5 @@ edition = "2018"
 description = "Expack is wrapper for any packaging wrappers"
 
 [dependencies]
+dirs = "3.0.1"
 once_cell = "1.7.2"

--- a/src/init.rs
+++ b/src/init.rs
@@ -10,7 +10,7 @@ fn get_expath() -> PathBuf {
     let expath = match env::var("EXPATH") {
         Ok(path) => PathBuf::from(path),
         Err(_) => {
-            let mut home = env::home_dir().expect("Home directory not found");
+            let mut home = dirs::home_dir().expect("Home directory not found");
             home.push(".expack");
             home
         },


### PR DESCRIPTION
Close #18  .
# Contents
Change home_dir from deprecated to recommended.
# Reason
I don't want to see the warning display.
# Impact
Install dirs crate.
Change env::home_dir to dirs::home_dir.