### PR TITLE
Remove init

### DIFF
--- a/src/init.rs
+++ b/src/init.rs
@@ -1,5 +1,0 @@
-use std::path::PathBuf;
-use std::env;
-
-pub(crate) fn init() {
-}

--- a/src/init.rs
+++ b/src/init.rs
@@ -3,15 +3,3 @@ use std::env;
 
 pub(crate) fn init() {
 }
-
-pub(crate) fn get_expath() -> PathBuf {
-    let expath = match env::var("EXPATH") {
-        Ok(path) => PathBuf::from(path),
-        Err(_) => {
-            let mut home = dirs::home_dir().expect("Home directory not found");
-            home.push(".expack");
-            home
-        },
-    };
-    expath
-}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,6 @@ use std::env;
 mod init;
 
 fn main() {
-    init::init();
     println!("Hello, world!");
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,5 @@
 use std::path::PathBuf;
 use std::env;
-mod init;
 
 fn main() {
     println!("Hello, world!");

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,20 @@
 use std::path::PathBuf;
+use std::env;
 mod init;
 
 fn main() {
     init::init();
     println!("Hello, world!");
+}
+
+pub(crate) fn get_expath() -> PathBuf {
+    let expath = match env::var("EXPATH") {
+        Ok(path) => PathBuf::from(path),
+        Err(_) => {
+            let mut home = dirs::home_dir().expect("Home directory not found");
+            home.push(".expack");
+            home
+        },
+    };
+    expath
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ fn main() {
     println!("Hello, world!");
 }
 
-pub(crate) fn get_expath() -> PathBuf {
+fn get_expath() -> PathBuf {
     let expath = match env::var("EXPATH") {
         Ok(path) => PathBuf::from(path),
         Err(_) => {


### PR DESCRIPTION
Close #24  .
# Contents
Remove init.rs.
# Reason
It will be easier to understand if it is integrated into main.rs.
# Impact
Move get_expath function from init.rs to main.rs.
Import std::env to main.rs.
Change public setting of get_expath function from public to private.
Remove init call of main function.
Delete init.rs.