### PR TITLE
Move get_expath function from main.rs to init.rs

### DIFF
--- a/src/init.rs
+++ b/src/init.rs
@@ -19,3 +19,15 @@ fn init(expath: PathBuf,file: String) -> EnvConf {
         src: PathBuf.from("/home/foo/.expack/pack/bar/pack"),
     }
 }
+
+fn get_expath() -> PathBuf {
+    let expath = match env::var("EXPATH") {
+        Ok(path) => PathBuf::from(path),
+        Err(_) => {
+            let mut home = dirs::home_dir().expect("Home directory not found");
+            home.push(".expack");
+            home
+        },
+    };
+    expath
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,15 +4,3 @@ use std::env;
 fn main() {
     println!("Hello, world!");
 }
-
-fn get_expath() -> PathBuf {
-    let expath = match env::var("EXPATH") {
-        Ok(path) => PathBuf::from(path),
-        Err(_) => {
-            let mut home = dirs::home_dir().expect("Home directory not found");
-            home.push(".expack");
-            home
-        },
-    };
-    expath
-}


### PR DESCRIPTION
Close #33  .
# Contents
Move get_expath function from main.rs to init.rs.
# Reason
I want to use it only in the init function.
# Impact
Add get_expath fuction in init.rs.
Remove get_expath function from main.rs.