### PR TITLE
Remove expath argument of init function

### DIFF
--- a/src/init.rs
+++ b/src/init.rs
@@ -9,7 +9,7 @@ struct EnvConf {
     src: PathBuf,
 }
 
-fn init(expath: PathBuf,file: String) -> EnvConf {
+fn init(file: String) -> EnvConf {
     EnvConf {
         expath: PathBuf.from("/home/foo/.expack"),
         bin: PathBuf.from("/home/foo/.expack/bin"),


### PR DESCRIPTION
Close #35 .
# Contents
Remove expath argument of init function.
# Reason
I want to use get_expath function.
# Impact
Change the argument of the init function to `file: String` only.