### PR TITLE
Add read_file function

### DIFF
--- a/src/read_src.rs
+++ b/src/read_src.rs
@@ -1,0 +1,6 @@
+use std::path::PathBuf;
+use std::fs::read_to_string;
+
+fn read_file(src: PathBuf) -> String {
+    read_to_string(src.display().to_string()).expect("File not found")
+}


### PR DESCRIPTION
Close #43 .
# Contents
Add a function to read the contents of a file.
# Reason
I want to read the contents of the pack file.
# Impact
Add read_file function in read_src.rs.
Import std::path::PathBuf in read_src.rs.
Import std::fs::read_to_string in read_src.rs.