### PR TITLE
Add get_src function

### DIFF
--- a/src/init.rs
+++ b/src/init.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 use std::env;
+use std::fs::read_to_string;
 
 pub(crate) struct EnvConf {
     expath: PathBuf,
@@ -8,6 +9,12 @@ pub(crate) struct EnvConf {
     base: PathBuf,
     files: PathBuf,
     src: PathBuf,
+}
+
+impl EnvConf {
+    pub(crate) fn get_src(&self) -> String {
+        read_to_string(self.src.display().to_string()).expect("File not found")
+    }
 }
 
 pub(crate) fn init(file: String) -> EnvConf {

--- a/src/read_src.rs
+++ b/src/read_src.rs
@@ -1,9 +1,4 @@
 use std::path::PathBuf;
-use std::fs::read_to_string;
-
-fn read_file(src: PathBuf) -> String {
-    read_to_string(src.display().to_string()).expect("File not found")
-}
 
 fn format(src: String) -> String {
     let pieces = src.split("\n");

--- a/src/read_src.rs
+++ b/src/read_src.rs
@@ -1,4 +1,5 @@
 use std::path::PathBuf;
+use crate::init;
 
 fn format(src: String) -> String {
     let pieces = src.split("\n");
@@ -21,4 +22,8 @@ fn conv_token(src: String) -> Vec<Vec<String>> {
         token.push(tmp);
     }
     token
+}
+
+pub(crate) fn get_src(src: init::EnvConf) -> Vec<Vec<String>> {
+    conv_token(format(src.get_src()))
 }


### PR DESCRIPTION
Close #51 .
# Contents
Add a function to get the source code.
# Reason
I want to get the source from the file name.
# Impact
Import std::fs::read_to_string in init.rs
Add init::EnvConf::get_src()
Uninstall std::fs::read_to_string in read_src.rs
Import crate::init in read_src.rs
Add read_src::get_src()