### PR TITLE
Add alias Src

### DIFF
--- a/src/read_src.rs
+++ b/src/read_src.rs
@@ -1,6 +1,8 @@
 use std::path::PathBuf;
 use crate::init;
 
+type Src = Vec<Vec<String>>;
+
 fn format(src: String) -> String {
     let pieces = src.split("\n");
     let mut result = String::new();

--- a/src/read_src.rs
+++ b/src/read_src.rs
@@ -14,8 +14,8 @@ fn format(src: String) -> String {
     result
 }
 
-fn conv_token(src: String) -> Vec<Vec<String>> {
-    let mut token: Vec<Vec<String>> = Vec::new();
+fn conv_token(src: String) -> Src {
+    let mut token: Src = Vec::new();
     for i in src.split("\n") {
         let mut tmp = Vec::new();
         for j in i.split(" ") {
@@ -26,6 +26,6 @@ fn conv_token(src: String) -> Vec<Vec<String>> {
     token
 }
 
-pub(crate) fn get_src(src: init::EnvConf) -> Vec<Vec<String>> {
+pub(crate) fn get_src(src: init::EnvConf) -> Src {
     conv_token(format(src.get_src()))
 }


### PR DESCRIPTION
Close #57 .
# Contents
Add alias Src to Vec\<Vec\<String\>\>.
# Reason
I want to change Vec\<Vec\<String\>\> to Src.
# Impact
Add alias Src to Vec\<Vec\<String\>\> in read_src.rs.
Change from Vec\<Vec\<String\>\> to Src.