### PR TITLE
Add get_cmd_path function in EnvConf

### DIFF
--- a/src/init.rs
+++ b/src/init.rs
@@ -15,6 +15,11 @@ impl EnvConf {
     pub(crate) fn get_src(&self) -> String {
         read_to_string(self.src.display().to_string()).expect("File not found")
     }
+    pub(crate) fn get_cmd_path(&self, cmd: &str) -> String {
+        let mut path = self.bin.clone();
+        path.push(cmd);
+        path.display().to_string()
+    }
 }
 
 pub(crate) fn init(file: String) -> EnvConf {


### PR DESCRIPTION
Close #59 .
# Contents
Add a function to get the command path in EnvConf.
# Reason
I want to know the path of the command to be executed.
# Impact
Add get_cmd_path function of EnvConf in init.rs.