### PR TITLE
Change return type of get_src function

### DIFF
--- a/src/read_src.rs
+++ b/src/read_src.rs
@@ -58,6 +58,6 @@ fn src_to_cmds(src: Src) -> HashMap<String,Src> {
     cmds
 }
 
-pub(crate) fn get_src(src: init::EnvConf) -> Src {
-    conv_token(format(src.get_src()))
+pub(crate) fn get_src(src: init::EnvConf) -> HashMap<String,Src> {
+    src_to_cmds(conv_token(format(src.get_src())))
 }


### PR DESCRIPTION
Close #67 .
# Contents
Change the return type of the get_src function to HashMap\<String,Src\>.
# Reason
I want to make command execution easier.
# Impact
Change the return type of the get_src function from Src to HashMap\<String,Src\>.