### PR TITLE
Remove key != "".to_string()

### DIFF
--- a/src/read_src.rs
+++ b/src/read_src.rs
@@ -15,12 +15,6 @@ fn format(src: String) -> String {
     result.trim().to_string()
 }
 
-#[test]
-fn format_test() {
-    let test_src = "main ls\nsub ls -A\ninstall {\necho ls\necho Install\n}\n";
-    println!("{}",format(test_src.to_string()));
-}
-
 fn conv_token(src: String) -> Src {
     let mut token: Src = Vec::new();
     for i in src.split("\n") {
@@ -55,7 +49,7 @@ fn src_to_cmds(src: Src) -> HashMap<String,Src> {
         if tmp.len() > 0 {
             val.push(tmp.clone());
         }
-        if !fn_flag & (key != "".to_string()) {
+        if !fn_flag {
             cmds.insert(key.clone(),val.clone());
             key = String::new();
             val = Vec::new();

--- a/src/read_src.rs
+++ b/src/read_src.rs
@@ -12,7 +12,13 @@ fn format(src: String) -> String {
             result = format!("{}{}\n",result,i.trim());
         }
     }
-    result
+    result.trim().to_string()
+}
+
+#[test]
+fn format_test() {
+    let test_src = "main ls\nsub ls -A\ninstall {\necho ls\necho Install\n}\n";
+    println!("{}",format(test_src.to_string()));
 }
 
 fn conv_token(src: String) -> Src {


### PR DESCRIPTION
Close #69 .
# Contents
Remove `key != "".to_string()` of src_to_cmds function.
# Reason
I want to delete `key != "".to_string()` of src_to_cmds function.
# Impact
Change the return value of format function to return.trim().to_string().
Remove `key != "".to_string()` of src_to_cmds function.
